### PR TITLE
알림 프로토콜에 deeplink_url 필드를 추가

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+Version 2.1.0 (2020-07-02)
+==========================
+- NotificationMessage 에 deeplink_url 필드 추가
+- NotificationCenterMessage 에 deeplink_url 필드 추가
+
 Version 2.0.0 (2020-01-30)
 ==========================
 - Ridibooks\Crm\Client::getQueueStatusAsync 제거

--- a/src/Ridibooks/Crm/Notification/Payload/NotificationCenterMessage.php
+++ b/src/Ridibooks/Crm/Notification/Payload/NotificationCenterMessage.php
@@ -35,6 +35,10 @@ class NotificationCenterMessage implements \JsonSerializable
      * @var int
      */
     private $expire_at;
+    /**
+     * @var string
+     */
+    private $deeplink_url;
 
     /**
      * 알림센터 메시지 페이로드 생성자.
@@ -51,6 +55,7 @@ class NotificationCenterMessage implements \JsonSerializable
      * @param string $image_type 이미지 유형 ({@see ImageType})
      * @param string $landing_url 메시지를 눌렀을 때 이동할 주소
      * @param int $expire_at 메시지가 만료될 유닉스 시간 * 1000 (밀리초)
+     * @param string $deeplink_url 안드로이드 앱에서 메시지를 눌렀을 때 이동할 주소
      */
     public function __construct(
         array $u_ids,
@@ -59,7 +64,8 @@ class NotificationCenterMessage implements \JsonSerializable
         string $image_url,
         string $image_type,
         string $landing_url,
-        int $expire_at
+        int $expire_at,
+        string $deeplink_url = null
     ) {
         $this->u_ids = $u_ids;
         $this->identifier = $identifier;
@@ -68,6 +74,7 @@ class NotificationCenterMessage implements \JsonSerializable
         $this->image_type = $image_type;
         $this->landing_url = $landing_url;
         $this->expire_at = $expire_at;
+        $this->deeplink_url = $deeplink_url;
     }
 
     public function jsonSerialize()
@@ -80,6 +87,7 @@ class NotificationCenterMessage implements \JsonSerializable
             'image_type' => $this->image_type,
             'landing_url' => $this->landing_url,
             'expire_at' => $this->expire_at,
+            'deeplink_url' => $this->deeplink_url
         ];
     }
 }

--- a/src/Ridibooks/Crm/Notification/Payload/NotificationMessage.php
+++ b/src/Ridibooks/Crm/Notification/Payload/NotificationMessage.php
@@ -35,6 +35,10 @@ class NotificationMessage implements \JsonSerializable
      * @var int
      */
     private $expire_at;
+    /**
+     * @var string
+     */
+    private $deeplink_url;
 
     /**
      * 알림센터 메시지 페이로드 생성자.
@@ -51,6 +55,7 @@ class NotificationMessage implements \JsonSerializable
      * @param string $image_type 이미지 유형 ({@see ImageType})
      * @param string $landing_url 메시지를 눌렀을 때 이동할 주소
      * @param int $expire_at 메시지가 만료될 유닉스 시간 * 1000 (밀리초)
+     * @param string $deeplink_url 안드로이드 앱에서 메시지를 눌렀을 때 이동할 주소
      */
     public function __construct(
         array $u_idxes,
@@ -59,7 +64,8 @@ class NotificationMessage implements \JsonSerializable
         string $image_url,
         string $image_type,
         string $landing_url,
-        int $expire_at
+        int $expire_at,
+        string $deeplink_url = null
     ) {
         $this->u_idxes = $u_idxes;
         $this->identifier = $identifier;
@@ -68,6 +74,7 @@ class NotificationMessage implements \JsonSerializable
         $this->image_type = $image_type;
         $this->landing_url = $landing_url;
         $this->expire_at = $expire_at;
+        $this->deeplink_url = $deeplink_url;
     }
 
     public function jsonSerialize()
@@ -80,6 +87,7 @@ class NotificationMessage implements \JsonSerializable
             'image_type' => $this->image_type,
             'landing_url' => $this->landing_url,
             'expire_at' => $this->expire_at,
+            'deeplink_url' => $this->deeplink_url
         ];
     }
 }


### PR DESCRIPTION
crm-private, store 에서 사용하는 crm client 입니다. [안드 연재 상세](https://app.asana.com/0/1170388054670006/1170388054670006) 와 관련하여, 알림(center) 메시지에 안드로이드가 사용할 deeplink 정보 추가가 필요해, 본 라이브러리를 아래와 같이 업데이트 합니다.

- NotificationMessage 에  deeplink_url 추가 (기존 코드와 호환위해, 기본값 null 처리함)
- NotificationCenterMessage 에 deeplink_url 추가  (기존 코드와 호환위해, 기본값 null 처리함)

